### PR TITLE
Found a typo

### DIFF
--- a/src/main/java/com/sovereigncraft/economy/SCEconomy.java
+++ b/src/main/java/com/sovereigncraft/economy/SCEconomy.java
@@ -31,7 +31,7 @@ public final class SCEconomy extends JavaPlugin {
         instance = this;
         vaultImpl = new VaultImpl();
         if (!setupEconomy()) {
-            disable("Economy couldn't be registed, Vault plugin is missing!");
+            disable("Economy couldn't be registered, Vault plugin is missing!");
             return;
         }
         this.getLogger().info("Vault found, Economy has been registered.");


### PR DESCRIPTION
Changed: `disable("Economy couldn't be registed, Vault plugin is missing!");`
To: `disable("Economy couldn't be registered, Vault plugin is missing!");`