### PR TITLE
Fix documentation typos

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,11 +6,11 @@ currencyNamePlural: "Sats"
 startingBalance: 100
 customSymbol: "⚡"
 
-#UUID of wallet to provide liquidity or a "Float" Can be generated as a random generator
+#UUID of wallet to provide liquidity or a "Float". Can be generated using a random generator
 ServerUUID: ""
 #AdminKey of Admin wallet (top level in LN bits)
 AdminKey:
-#Apikey from usermanager user
+#API key from usermanager user
 APIKey:
 #Admin User for main wallet
 AdminUser:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -36,7 +36,7 @@ commands:
   withdraw:
     description: Withdraw Lightning with a QR screen in game
   acceptTOS:
-    description: Creates a new Lighting wallet if one does not exist. Please read TOS first.
+    description: Creates a new Lightning wallet if one does not exist. Please read TOS first.
   refreshwallet:
     description: regenerates wallet in case it was compromised
 #  playerqr:


### PR DESCRIPTION
## Summary
- revert README typo changes
- keep comment improvements in `config.yml`
- keep command description fix in `plugin.yml`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b0142bf088328954f8521fc81a99a