### PR TITLE
Fix Vault API dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,16 @@
                     <goals>
                         <goal>shade</goal>
                     </goals>
+                    <configuration>
+                        <filters>
+                            <filter>
+                                <artifact>com.github.MilkBowl:VaultAPI</artifact>
+                                <excludes>
+                                    <exclude>org/bukkit/inventory/meta/**</exclude>
+                                </excludes>
+                            </filter>
+                        </filters>
+                    </configuration>
                 </execution>
             </executions>
         </plugin>
@@ -98,8 +108,7 @@
             <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
             <version>1.7</version>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/Vault-1.7.3.jar</systemPath>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,15 +105,15 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.MilkBowl</groupId>
-            <artifactId>VaultAPI</artifactId>
-            <version>1.7</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.19.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.MilkBowl</groupId>
+            <artifactId>VaultAPI</artifactId>
+            <version>1.7</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- use the published Vault API instead of a local jar
- filter out Bukkit inventory meta classes from Vault when shading

## Testing
- `mvn -q -e -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b7976c0748328b77b5ef04198ae38